### PR TITLE
Return all user's roles instead of a single role

### DIFF
--- a/src/controller/authController.js
+++ b/src/controller/authController.js
@@ -48,15 +48,9 @@ async function registerUserController(req, res) {
         const token = authHeader.split(' ')[1]
         try {
           const decoded = jwt.verify(token, JWT_SECRET)
-          const user = await User.findById(decoded.userId).select('email roles profile.name')
-
-          if (user) {
-            userData = {
-              name: user.profile.name,
-              email: user.email || null,
-              roles: user.roles
-            }
-          }
+          userData = await User.findById(decoded.userId)
+          .select('-password')
+          .lean();
         } catch (err) {
           userData = null
         }

--- a/src/controller/authController.js
+++ b/src/controller/authController.js
@@ -54,7 +54,7 @@ async function registerUserController(req, res) {
             userData = {
               name: user.profile.name,
               email: user.email || null,
-              role: user.roles[0]
+              roles: user.roles
             }
           }
         } catch (err) {


### PR DESCRIPTION
I noticed that a single user can have more than one role (in some circumstances?)
If that is the case, I think we should just return all roles (and modify frontend logic)